### PR TITLE
Removed Routes, Fare and Metro map from home navbar

### DIFF
--- a/lib/pages/cities_page.dart
+++ b/lib/pages/cities_page.dart
@@ -21,9 +21,6 @@ class _CitiesPageState extends State<CitiesPage> {
 
   final fragmentTitles = [
     "About",
-    "Routes",
-    "Fare",
-    "Metro Map",
     "Settings",
     "Send Feedback",
     "Share",
@@ -34,9 +31,6 @@ class _CitiesPageState extends State<CitiesPage> {
 
   final fragmentRoutes = [
     "about",
-    "routes",
-    "fare",
-    "metroMap",
     "settings",
     "sendFeedback",
     "share",
@@ -46,9 +40,6 @@ class _CitiesPageState extends State<CitiesPage> {
   ];
   final List<Widget> fragmentIcons = [
     Icon(Icons.info, color: Colors.blue),
-    Icon(Icons.navigation, color: Colors.blue),
-    Icon(Icons.monetization_on, color: Colors.blue),
-    Icon(Icons.map, color: Colors.blue),
     Icon(Icons.settings, color: Colors.blue),
     Icon(Icons.feedback, color: Colors.blue),
     Icon(Icons.share, color: Colors.blue),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -109,6 +109,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.4"
+  pedantic:
+    dependency: transitive
+    description:
+      name: pedantic
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.8.0+1"
   petitparser:
     dependency: transitive
     description:
@@ -176,7 +183,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.15"
+    version: "0.2.11"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
Solved issue #34 

Check the screenshot below for reference - 

The home navbar now looks like this - 

![metro_app_issue_fixed_2](https://user-images.githubusercontent.com/31125152/77930388-74fd3b80-72c8-11ea-916c-9eb0ee9e8ecd.jpeg)
